### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,8 @@
 name: PR Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
    branches:


### PR DESCRIPTION
Potential fix for [https://github.com/project-sunbird/sunbird-telemetry-service/security/code-scanning/1](https://github.com/project-sunbird/sunbird-telemetry-service/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block that restricts the `GITHUB_TOKEN` to the minimal scopes required. For this workflow, all steps are read-only with respect to repository contents and packages; they only need to read the code and possibly read packages, and do not require write permissions.

The single best fix here is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`) so it applies to all jobs. We can follow CodeQL’s minimal suggestion and set `contents: read`. None of the actions used (`actions/checkout`, `actions/setup-node`, `actions/cache`) require write access to repository contents; cache functionality uses its own backend and does not require repo writes. Concretely, in `.github/workflows/pull_request.yml`, insert:

```yml
permissions:
  contents: read
```

between the `name: PR Check` line and the `on:` block. This does not change any functional behavior of the workflow except tightening the token’s privileges, and requires no additional imports or methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
