### PR TITLE
Add Dependabot configuration for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,17 @@ updates:
           - "qs"
           - "debug"
           - "tough-cookie"
+          - "request"
+      testing:
+        patterns:
+          - "chai*"
+          - "mocha*"
+          - "mochawesome*"
+          - "nyc"
+          - "sinon"
+      linting:
+        patterns:
+          - "eslint*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/src"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"
+    groups:
+      express:
+        patterns:
+          - "express*"
+          - "body-parser"
+          - "morgan"
+          - "cookie-parser"
+          - "http-errors"
+          - "send"
+          - "helmet"
+      logging:
+        patterns:
+          - "winston*"
+      kafka:
+        patterns:
+          - "kafkajs"
+      utility:
+        patterns:
+          - "lodash"
+          - "uuid"
+          - "qs"
+          - "debug"
+          - "tough-cookie"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:00"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -15,16 +15,20 @@ permissions:
 jobs:
   submission:
     runs-on: ubuntu-latest
+    # Skip fork PRs — they don't have contents: write access
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '23'
+          node-version: '22'
 
       - name: Generate fresh lock file
-        run: npm install --package-lock-only
+        run: |
+          rm -f package-lock.json
+          npm install --package-lock-only
         working-directory: ./src
 
       - name: Generate SPDX SBOM
@@ -36,4 +40,4 @@ jobs:
         with:
           filePath: './src'
           filePattern: 'dependency.spdx.json'
-          correlator: 'backend'
+          correlator: 'telemetry-service-npm'

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,39 @@
+name: 'Dependency Submission'
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '0 3 * * 1'  # Every Monday at 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write  # Required by the Dependency Submission API
+
+jobs:
+  submission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '23'
+
+      - name: Generate fresh lock file
+        run: npm install --package-lock-only
+        working-directory: ./src
+
+      - name: Generate SPDX SBOM
+        run: npm sbom --sbom-format=spdx --package-lock-only > dependency.spdx.json
+        working-directory: ./src
+
+      - name: Submit Dependency Graph
+        uses: advanced-security/spdx-dependency-submission-action@v0.2.0
+        with:
+          filePath: './src'
+          filePattern: 'dependency.spdx.json'
+          correlator: 'backend'


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable automated dependency update PRs via Dependabot
- Adds `.github/workflows/dependency-submission.yml` to submit the full direct and transitive dependency graph to GitHub's Dependency Submission API

## Dependabot Configuration (`.github/dependabot.yml`)

Configures two ecosystems with weekly updates every Monday at 03:00 UTC:

- **npm** — targets the `src/` directory (where `package.json` lives), with dependency grouping to reduce PR noise:
  - `express` — express, body-parser, morgan, cookie-parser, http-errors, send, helmet
  - `logging` — winston, winston-cassandra, winston-daily-rotate-file
  - `kafka` — kafkajs
  - `utility` — lodash, uuid, qs, debug, tough-cookie
- **github-actions** — keeps workflow action versions current

## Dependency Submission Workflow (`.github/workflows/dependency-submission.yml`)

Triggers on push to `master`, PRs to `master`, weekly on Mondays at 03:00 UTC, and manual dispatch.

**Flow:**
1. `npm install --package-lock-only` — generates a fresh `package-lock.json` on the runner (never committed to the repo)
2. `npm sbom --sbom-format=spdx --package-lock-only` — produces an SPDX 2.3 Bill of Materials (`dependency.spdx.json`) covering all direct and transitive packages
3. `advanced-security/spdx-dependency-submission-action@v0.2.0` — submits the SPDX file to GitHub's Dependency Submission API

This ensures Dependabot security alerts cover the full resolved dependency tree (200+ transitive packages), not just the ~18 direct dependencies listed in `package.json`.

## Test plan

- [ ] Confirm `.github/dependabot.yml` is valid — check **Insights → Dependency Graph → Dependabot** on GitHub after merge
- [ ] Trigger the **Dependency Submission** workflow manually via `workflow_dispatch` and confirm it completes successfully
- [ ] Check **Insights → Dependency Graph** — transitive packages should appear (hundreds, not just direct ones)
- [ ] Check **Security → Dependabot alerts** — alerts for transitive dependency CVEs should now surface
- [ ] Verify Dependabot opens grouped PRs on the next Monday schedule
- [ ] Confirm existing CI workflows (`PR Check`, `Build and Publish Docker Image`) are unaffected